### PR TITLE
Simplify HDF5 and Mojo datasources for single channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# Remote debugging
+butterfly/debug.py
+*.swp
+
 # PyBuilder
 target/
 .idea

--- a/butterfly/hdf5.py
+++ b/butterfly/hdf5.py
@@ -78,6 +78,7 @@ class HDF5DataSource(DataSource):
                 cutout = ds[z, y0:y1:(2 ** w), x0:x1:(2 ** w)]
                 result[:cutout.shape[0], :cutout.shape[1]] = cutout
                 return result
+            return ds[z, y0:y1:(2 ** w), x0:x1:(2 ** w)]
 
     def load(self, x, y, z, w, segmentation=False):
         '''

--- a/butterfly/hdf5.py
+++ b/butterfly/hdf5.py
@@ -10,9 +10,6 @@ import settings
 
 from .datasource import DataSource
 
-'''The JSON dictionary key for layer channel type'''
-K_CHANNEL = 'channel'
-
 '''The JSON dictionary key for the filename (including path) of the HDF5 file'''
 K_FILENAME = 'filename'
 
@@ -48,7 +45,6 @@ class HDF5DataSource(DataSource):
                 return {
                     K_FILENAME : path,
                     K_DATASET_PATH : key0,
-                    K_CHANNEL : fd[key0].dtype
                 }
         else:
             return False

--- a/butterfly/hdf5.py
+++ b/butterfly/hdf5.py
@@ -19,77 +19,56 @@ K_FILENAME = 'filename'
 '''The JSON dictionary key of the path to the dataset inside the HDF5 file'''
 K_DATASET_PATH = 'dataset-path'
 
-'''The default filenames data if no JSON file'''
-K_PRESET_FILENAMES = ['image.h5','segmentation.h5','synapse.h5']
-
-'''The default channels by array index if not in JSON file'''
-K_PRESET_CHANNELS = ['img','seg','syn']
-
 class HDF5DataSource(DataSource):
     '''An HDF5 data source
-    
+
     An HDF5 data source consists of a .json file that contains a dictionary
     with the following keys:
-    
+
     filename: the name of the HDF5 file
     dataset-path: the path inside the HDF5 file to the dataset
-    
+
     The dataset may be sparse (with zero for areas w/o data) so the coordinate
     system is implicit, starting at 0, 0, 0.
     '''
-    
+
     def __init__(self, core, datapath, dtype=np.uint8):
-        layers = self.defaultLayers(datapath)
-        if not layers:
+        self._dataset = self.loadFolder(datapath)
+        if not self._dataset:
             warn = "HDF5 path %s must point to valid h5" % datapath
             raise IndexError(warn)
-        self.channels = self.storeChannels(layers)
-        self.kinds = list(self.channels.keys())
         super(HDF5DataSource, self).__init__(core, datapath)
 
-    def defaultLayers(self,path):
-        layers = []
+    def loadFolder(self,path):
         if path.endswith('.json'):
-            layers = json.load(open(path, "r"))
-            if type(layers) is not list:
-                layers = [layers]
-        elif os.path.isdir(path):
-            h5files = [i for i in os.listdir(path) if i.endswith('.h5')]
-            if h5files:
-                for name, kind in zip(K_PRESET_FILENAMES,K_PRESET_CHANNELS):
-                    if name in h5files:
-                        fullName = os.path.join(path,name)
-                        with h5py.File(fullName, "r") as fd:
-                            layer = dict([(K_FILENAME, fullName)])
-                            layer[K_DATASET_PATH] = fd.keys()[0]
-                            layer[K_CHANNEL] = kind
-                            layers.append(layer)
-        return layers
-
-    def kindGuess(self,id):
-        return K_PRESET_CHANNELS[int(id)%len(K_PRESET_CHANNELS)]
-
-    def storeChannels(self,layers):
-        channels = {}
-        for lid,layer in enumerate(layers):
-            if K_CHANNEL not in layer:
-                layer[K_CHANNEL] = self.kindGuess(lid)
-            channels[layer[K_CHANNEL]] = layer
-        return channels
+            return json.load(open(path, "r"))
+        elif path.endswith('.h5'):
+            with h5py.File(path, "r") as fd:
+                key0 = fd.keys()[0]
+                return {
+                    K_FILENAME : path,
+                    K_DATASET_PATH : key0,
+                    K_CHANNEL : fd[key0].dtype
+                }
+        else:
+            return False
 
     def index(self):
-        firstChannel = self.channels[self.kinds[0]]
-        with h5py.File(firstChannel[K_FILENAME], "r") as fd:
-            self.blocksize = fd[firstChannel[K_DATASET_PATH]].shape[-1:0:-1]
-        return
-    
+        '''
+        @override
+        '''
+        with h5py.File(self._dataset[K_FILENAME], "r") as fd:
+            dataset = fd[self._dataset[K_DATASET_PATH]]
+            self.blocksize = dataset.shape[1:][::-1]
+
+        super(HDF5DataSource, self).index()
+
     def load_cutout(self, x0, x1, y0, y1, z, w):
-        channelKind = self.kindGuess(0)
-        if channelKind not in self.kinds:
-            return 0
-        channel = self.channels[channelKind]
-        with h5py.File(channel[K_FILENAME], "r") as fd:
-            ds = fd[channel[K_DATASET_PATH]]
+        '''
+        @override
+        '''
+        with h5py.File(self._dataset[K_FILENAME], "r") as fd:
+            ds = fd[self._dataset[K_DATASET_PATH]]
             if z >= ds.shape[0]:
                 return np.zeros(((y1 - y0) / (2 ** w),
                                  (x1-x0) / (2**w)), dtype=ds.dtype)
@@ -99,17 +78,15 @@ class HDF5DataSource(DataSource):
                 cutout = ds[z, y0:y1:(2 ** w), x0:x1:(2 ** w)]
                 result[:cutout.shape[0], :cutout.shape[1]] = cutout
                 return result
-            return ds[z, y0:y1:(2 ** w), x0:x1:(2 ** w)]
 
-    def load(self, x, y, z, w, segmentation):
-        channelKind = self.kindGuess(segmentation)
-        if channelKind not in self.kinds:
-            return 0
-        channel = self.channels[channelKind]
-        with h5py.File(channel[K_FILENAME], "r") as fd:
-            (bx,by) = self.blocksize
-            ds = fd[channel[K_DATASET_PATH]]
-            return ds[z, y:y+by:(2 ** w), x:x+bx:(2 ** w)]
+    def load(self, x, y, z, w, segmentation=False):
+        '''
+        @override
+        '''
+        (bx,by) = self.blocksize
+        with h5py.File(self._dataset[K_FILENAME], "r") as fd:
+            dataset = fd[self._dataset[K_DATASET_PATH]]
+            return dataset[z, y:y+by:(2 ** w), x:x+bx:(2 ** w)]
 
     def seg_to_color(self, slice):
         colors = np.zeros(slice.shape+(3,),dtype=np.uint8)
@@ -117,21 +94,9 @@ class HDF5DataSource(DataSource):
         colors[:,:,1] = np.mod(509*slice[:,:],900).astype(np.uint8)
         colors[:,:,2] = np.mod(200*slice[:,:],777).astype(np.uint8)
         return colors
-    
-    def get_boundaries(self):
-        firstChannel = self.channels[self.kinds[0]]
-        with h5py.File(firstChannel[K_FILENAME], "r") as fd:
-            return fd[firstChannel[K_DATASET_PATH]].shape[::-1]
 
-    def get_dataset(self,path):
-        dataset = {'name':os.path.basename(path),'channels':[]}
-        dimensions = dict(zip(('x','y','z'),self.get_boundaries()))
-        for kind,channel in self.channels.iteritems():
-            innerPath = channel[K_DATASET_PATH]
-            base = os.path.splitext(os.path.basename(channel[K_FILENAME]))[0]
-            base += ' '+os.path.basename(innerPath)
-            subset = {'path':path,'dimensions':dimensions,'name':base}
-            with h5py.File(channel[K_FILENAME], "r") as fd:
-                subset['data-type'] = fd[innerPath].dtype.name
-            dataset['channels'].append(subset)
-        return dataset
+    def get_boundaries(self):
+        with h5py.File(self._dataset[K_FILENAME], "r") as fd:
+            dataset = fd[self._dataset[K_DATASET_PATH]]
+            self.blocksize = dataset.shape[::-1]
+        return self.blocksize

--- a/butterfly/multibeam.py
+++ b/butterfly/multibeam.py
@@ -79,7 +79,7 @@ class MultiBeam(DataSource):
             section = self.ts[z][0].section
             return section.imread(x0, y0, x1, y1, w)
         return self.load_tilespec_cutout(x0, x1, y0, y1, z, w)
-    
+
     def load_tilespec_cutout(self, x0, x1, y0, y1, z, w):
         '''Load a cutout from tilespecs'''
         kdtree = self.kdtrees[z]
@@ -113,7 +113,7 @@ class MultiBeam(DataSource):
             single_renderers, blend_type='AVERAGING', dtype=self.dtype)
         return renderer.crop(
             int(x0 / 2**w), int(y0 / 2**w), int(x1 / 2**w), int(y1 / 2**w))[0]
-        
+
 
     def load(self, x, y, z, w, segmentation=False):
         '''

--- a/butterfly/tilespecs.py
+++ b/butterfly/tilespecs.py
@@ -79,7 +79,7 @@ class Tilespecs(DataSource):
         #    section = self.ts[z][0].section
         #    return section.imread(x0, y0, x1, y1, w)
         return self.load_tilespec_cutout(x0, x1, y0, y1, z, w)
-    
+
     def load_tilespec_cutout(self, x0, x1, y0, y1, z, w):
         '''Load a cutout from tilespecs'''
         if w > 0:
@@ -93,8 +93,6 @@ class Tilespecs(DataSource):
             model = AffineModel(m=np.eye(3) * 2.0 ** w)
             self.layer_renderer[z].add_transformation(model)
         return img
-        
-        
 
     def load(self, x, y, z, w, segmentation=False):
         '''


### PR DESCRIPTION
All datasources should only represent one channel. Currently Hdf5 and Mojo remain as the only datasources that allow the possibility of multiple image channels within them. 

This update removes a lot of the complexity previously added to support different channels in the hdf5 and mojo datasources.