### PR TITLE
Fixes #23 transmit 32-bit segmentations as RGBA

### DIFF
--- a/butterfly/restapi.py
+++ b/butterfly/restapi.py
@@ -222,6 +222,8 @@ class RestAPIHandler(RequestHandler):
             output.write(zlib.compress(volstring))
             content = output.getvalue()
         else:
+            if vol.dtype.itemsize == 4:
+                vol = vol.view(np.uint8).reshape(vol.shape[0], vol.shape[1], 4)
             content = cv2.imencode(  "." + fmt, vol)[1].tostring()
 
         self.write(content)


### PR DESCRIPTION
To decode, 

    result = cv2.imdecode(buffer, cv2.IMREAD_UNCHANGED)
    if result.ndim == 3:
        result = result.view(np.uint32).reshape(result.shape[0], result.shape[1])