### PR TITLE
Memory leak

### DIFF
--- a/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Keywords.py
+++ b/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Keywords.py
@@ -153,7 +153,7 @@ class RUNTIME():
         # ALL THE DATABASE RUNTIME TERMS
         self.DB = NamelessStruct(
             TABLE = NamelessStruct(
-                LIST = _table_list[:],
+                LIST = _table_list,
                 NEURON = NamedStruct(_table_list[0],
                     KEY = NamedStruct('neuron'),
                     KEY_LIST = ['neuron']

--- a/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Keywords.py
+++ b/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Keywords.py
@@ -228,10 +228,6 @@ Cannot cache {value}. {size} bytes is over max.
                 )
             ),
         )
-    def __del__(self):
-        print """
-
-        """
 
 '''
 THIS HELPS RETURN TEXT

--- a/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Keywords.py
+++ b/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Keywords.py
@@ -153,7 +153,7 @@ class RUNTIME():
         # ALL THE DATABASE RUNTIME TERMS
         self.DB = NamelessStruct(
             TABLE = NamelessStruct(
-                LIST = _table_list,
+                LIST = _table_list[:],
                 NEURON = NamedStruct(_table_list[0],
                     KEY = NamedStruct('neuron'),
                     KEY_LIST = ['neuron']
@@ -228,6 +228,10 @@ Cannot cache {value}. {size} bytes is over max.
                 )
             ),
         )
+    def __del__(self):
+        print """
+
+        """
 
 '''
 THIS HELPS RETURN TEXT

--- a/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Structures.py
+++ b/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Structures.py
@@ -4,6 +4,8 @@ from itertools import ifilter
 class NamelessStruct(object):
     VALUE = None
     def __init__(self,**_keywords):
+        self.LIST = []
+        self.SIBLINGS = []
         # Begin making the list
         all_list = _keywords.get('LIST',[])
         # Add other keywords to list
@@ -15,6 +17,8 @@ class NamelessStruct(object):
             more = keyval if is_list else []
             # Put all term names into list
             if hasattr(keyval, 'NAME'):
+                # DEBUG pass this list to child
+                keyval.SIBLINGS = self.LIST
                 more = [keyval.NAME]
             all_list += more
         if len(all_list):
@@ -58,7 +62,10 @@ class NamelessStruct(object):
 # For all keywords with names
 class NamedStruct(NamelessStruct):
     NAME = None
+
     def __init__(self,_name,**_keywords):
         NamelessStruct.__init__(self, **_keywords)
         self.NAME = _name
 
+    def __del__(self):
+        print 'still have {}'.format(self.SIBLINGS)

--- a/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Structures.py
+++ b/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Structures.py
@@ -4,19 +4,19 @@ from itertools import ifilter
 class NamelessStruct(object):
     VALUE = None
     def __init__(self,**_keywords):
-        # Begin making the list
-        all_list = _keywords.get('LIST',[])
+        # Begin a new list of all keyword NAMES
+        all_list = _keywords.get('LIST',[])[:]
         # Add other keywords to list
         for key in _keywords:
             keyval = _keywords[key]
             setattr(self,key,keyval)
             # Put all lists into list
-            is_list = isinstance(keyval,list)
-            more = keyval if is_list else []
-            # Put all term names into list
+            if isinstance(keyval, list):
+                all_list += keyval
+            # Put all keyword names into list
             if hasattr(keyval, 'NAME'):
-                more = [keyval.NAME]
-            all_list += more
+                all_list.append(keyval.NAME)
+        # If there are named keywords
         if len(all_list):
             all_set = set(all_list)
             all_key = all_list.index

--- a/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Structures.py
+++ b/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Structures.py
@@ -4,8 +4,6 @@ from itertools import ifilter
 class NamelessStruct(object):
     VALUE = None
     def __init__(self,**_keywords):
-        self.LIST = []
-        self.SIBLINGS = []
         # Begin making the list
         all_list = _keywords.get('LIST',[])
         # Add other keywords to list
@@ -17,8 +15,6 @@ class NamelessStruct(object):
             more = keyval if is_list else []
             # Put all term names into list
             if hasattr(keyval, 'NAME'):
-                # DEBUG pass this list to child
-                keyval.SIBLINGS = self.LIST
                 more = [keyval.NAME]
             all_list += more
         if len(all_list):
@@ -62,10 +58,7 @@ class NamelessStruct(object):
 # For all keywords with names
 class NamedStruct(NamelessStruct):
     NAME = None
-
     def __init__(self,_name,**_keywords):
         NamelessStruct.__init__(self, **_keywords)
         self.NAME = _name
 
-    def __del__(self):
-        print 'still have {}'.format(self.SIBLINGS)

--- a/bfly/CoreLayer/AccessLayer/UtilityLayer
+++ b/bfly/CoreLayer/AccessLayer/UtilityLayer
@@ -1,1 +1,0 @@
-../UtilityLayer/


### PR DESCRIPTION
Found and fixed memory leak at [line 156 of UtilityLayer/Keywords.py](https://github.com/Rhoana/butterfly/blob/update_v2/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Keywords.py#L156) due to passing list of database table `['neuron','synapse']` by reference instead of by values. 

The reference to this list gets passed as the `LIST` keyword of the `NamelessStruct` `RUNTIME.DB.TABLE`. The internals of the `NamelessStruct` in [Line 19 of UtilityLayer/Structures.py](https://github.com/Rhoana/butterfly/blob/update_v2/bfly/CoreLayer/AccessLayer/QueryLayer/UtilityLayer/Structures.py#L19) add each keyword argument `NAME` to the `LIST` keyword before adding unique vaules for `self.LIST`.

Although in `NamelessStruct` `self.LIST` contains only unique values, the original reference passed as the keyword argument `LIST` continues to accumulate values. This issue can be fixed by using python's `[:]` notation to create a copy of the list. 